### PR TITLE
Nakamasato patch 4

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -165,7 +165,7 @@ jobs:
 
       # pip キャッシュ用のアクション
       - name: Cache pip dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: pip-cache
         with:
           path: root-dot-cache-pip
@@ -185,9 +185,10 @@ jobs:
 
       # Docker イメージをビルドして必要に応じてプッシュ
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
         with:
-          context: .
+          context: docker-layer-cache
+          file: docker-layer-cache/Dockerfile.cache
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -55,7 +55,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-  build-and-push-image-claude:
+  build-and-push-image-multistage:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -130,3 +130,68 @@ jobs:
           echo "### 🐳 Docker Build Results" >> $GITHUB_STEP_SUMMARY
           echo "✅ Image built and pushed: \`${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}\`" >> $GITHUB_STEP_SUMMARY
           echo "🔖 Tags: ${{ steps.meta.outputs.tags }}" >> $GITHUB_STEP_SUMMARY
+
+  build-and-push-image-cache:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to the Container registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=sha
+
+      # pip キャッシュ用のアクション
+      - name: Cache pip dependencies
+        uses: actions/cache@v3
+        id: pip-cache
+        with:
+          path: root-dot-cache-pip
+          key: pip-cache-${{ hashFiles('requirements.txt') }}
+          restore-keys: |
+            pip-cache-
+
+      # buildkit-cache-dance を使ってキャッシュを Docker ビルドに注入
+      - name: Inject cache into Docker build
+        uses: reproducible-containers/buildkit-cache-dance@v3.1.0
+        with:
+          cache-map: |
+            {
+              "root-dot-cache-pip": "/root/.cache/pip"
+            }
+          skip-extraction: ${{ steps.pip-cache.outputs.cache-hit }}
+
+      # Docker イメージをビルドして必要に応じてプッシュ
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            BUILDKIT_INLINE_CACHE=1

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -139,14 +139,14 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
 
       - name: Log in to the Container registry
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -154,7 +154,7 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -165,7 +165,7 @@ jobs:
 
       # pip キャッシュ用のアクション
       - name: Cache pip dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
         id: pip-cache
         with:
           path: root-dot-cache-pip
@@ -175,7 +175,7 @@ jobs:
 
       # buildkit-cache-dance を使ってキャッシュを Docker ビルドに注入
       - name: Inject cache into Docker build
-        uses: reproducible-containers/buildkit-cache-dance@v3.1.0
+        uses: reproducible-containers/buildkit-cache-dance@5de31fc1534ed8789e63d41ea933c5df9944a261 # v3.1.0
         with:
           cache-map: |
             {

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -123,14 +123,6 @@ jobs:
           rm -rf /tmp/.buildx-cache
           mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
-      # ビルドの成功をGitHub上で視覚的に確認
-      - name: Build Summary
-        if: always()
-        run: |
-          echo "### 🐳 Docker Build Results" >> $GITHUB_STEP_SUMMARY
-          echo "✅ Image built and pushed: \`${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "🔖 Tags: ${{ steps.meta.outputs.tags }}" >> $GITHUB_STEP_SUMMARY
-
   build-and-push-image-cache:
     runs-on: ubuntu-latest
     permissions:

--- a/docker-layer-cache/Dockerfile.cache
+++ b/docker-layer-cache/Dockerfile.cache
@@ -1,0 +1,18 @@
+FROM python:3.12.7-slim
+
+WORKDIR /app
+
+# requirements.txtのみをコピー（レイヤーキャッシュ最適化）
+COPY requirements.txt .
+
+# pip cache を使用して依存関係をインストール
+RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
+    pip install -r requirements.txt
+
+# アプリケーションコードをコピー
+COPY . .
+
+ENV PORT=8080
+EXPOSE 8080
+
+CMD ["python", "app.py"]


### PR DESCRIPTION
This pull request includes significant updates to the Docker build and push workflow, specifically adding a new job for caching pip dependencies and optimizing Docker layer caching. Additionally, a new Dockerfile for caching has been introduced.

### Workflow updates:

* [`.github/workflows/build-and-push.yml`](diffhunk://#diff-ff6530072f2ee96cab1b3a1bd86c4db4afa00ae564f6484789969129711495aeL58-R58): Renamed the `build-and-push-image-claude` job to `build-and-push-image-multistage` to better reflect its purpose.
* [`.github/workflows/build-and-push.yml`](diffhunk://#diff-ff6530072f2ee96cab1b3a1bd86c4db4afa00ae564f6484789969129711495aeR133-R198): Added a new job `build-and-push-image-cache` to handle pip dependency caching and Docker layer caching. This job includes steps for setting up Docker Buildx, logging into the container registry, extracting metadata, caching pip dependencies, injecting cache into the Docker build, and building and pushing the Docker image.

### Dockerfile updates:

* [`docker-layer-cache/Dockerfile.cache`](diffhunk://#diff-27b98b9bb025d35cfcf80d950e9fa0b4b7a2947a24ce1b52808bf4a5566187c4R1-R18): Introduced a new Dockerfile for caching, which includes steps to copy `requirements.txt` for layer cache optimization, use pip cache to install dependencies, and copy the application code. It also sets the environment variable `PORT` and exposes port 8080.